### PR TITLE
README.md: fix invalid JSON in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ If you don't like modman files, you can define mappings in a package composer.js
       "magento-hackathon/magento-composer-installer": "*"
    },
     "extra": {
-        "map" : {
+        "map": [
             ["themes/default/skin", "public/skin/frontend/foo/default"],
             ["themes/default/design", "public/app/design/frontend/foo/default"],
             ["modules/My_Module/My_Module.xml", "public/app/etc/modules/My_Module.xml"],
             ["modules/My_Module/code", "public/app/code/local/My/Module"],
             ["modules/My_Module/frontend/layout/mymodule.xml", "public/app/design/frontend/base/default/layout/mymodule.xml"]
-        }
+        ]
     }
 }
 ```


### PR DESCRIPTION
This JSON was invalid and didn't work, it throws errors with `composer.phar validate`.

The updated version works as advertised and passes validation.
