### PR TITLE
simplexml_load_file needs a file.

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/PackageXmlParser.php
+++ b/src/MagentoHackathon/Composer/Magento/PackageXmlParser.php
@@ -108,7 +108,7 @@ class PackageXmlParser implements Parser
         $map = array();
 
         /** @var $package SimpleXMLElement */
-        $package = simplexml_load_file($this->getFile());
+        $package = simplexml_load_file($this->getFile()->getPathname());
         if (isset($package)) {
             foreach ($package->xpath('//contents/target') as $target) {
                 try {


### PR DESCRIPTION
[ErrorException]
  simplexml_load_file(): I/O warning : failed to load external entity "<?xml version="1.0"?>
  "

On all connect20 Packages.

Example:

"connect20/locale_mage_community_de_de": "*",
