### PR TITLE
Fixed package XML deployment for root directory targets

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/PackageXmlParser.php
+++ b/src/MagentoHackathon/Composer/Magento/PackageXmlParser.php
@@ -178,7 +178,7 @@ class PackageXmlParser implements Parser
                 if ($element->children()) {
                     foreach ($element->children() as $child) {
                         foreach ($this->getElementPaths($child) as $elementPath) {
-                            $elementPaths[] = $name . '/' . $elementPath;
+                            $elementPaths[] = $name == '.' ? $elementPath : $name . '/' . $elementPath;
                         }
                     }
                 } else {


### PR DESCRIPTION
Trying to deploy `Mage_All_Latest` with the composer installer results in a number of broken symlinks because the installer does not appear to handle files destined for the root directory correctly. Instead of deploying e.g. `./index.php` to `./index.php`, it is deployed to `././index.php`.

This PR fixes this behavior — however I am not sure if there is a better/more compatible way to do this. Feedback very welcome!
