### PR TITLE
Added bugfix to avoid removing whole folders in case modman is not well-...

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
@@ -243,6 +243,11 @@ abstract class DeploystrategyAbstract
             throw new \ErrorException("Source $sourcePath does not exists");
         }
 
+        // MP Avoid removing whole folders in case the modman file is not 100% well-written
+        // e.g. app/etc/modules/Testmodule.xml  app/etc/modules/ installs correctly, but would otherwise delete the whole app/etc/modules folder!
+        if (basename($sourcePath) !== basename($destPath)) {
+            $destPath .= '/' . basename($source);
+        }
         return self::rmdirRecursive($destPath);
     }
 


### PR DESCRIPTION
...written, e.g. when having app/etc/modules/Testmodule.xml app/etc/modules/ in modman, install will work, but module update would remove the whole app/etc/modules/ folder without this fix
