### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require":{
-        "composer-plugin-api":"*"
+        "composer-plugin-api": "1.0.0"
     },
     "require-dev":{
         "phpunit/phpunit":"*",


### PR DESCRIPTION
Changed the composer-plugin-api version from \* to 1.0.0

check: http://getcomposer.org/doc/articles/plugins.md#plugin-package

Prevents a RuntimeException: Plugin magento-hackathon/magento-composer-installer is missing a require statement for a version of the composer-plugin-api package. 
