### PR TITLE
Add ability to translate path mapping prefixes

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Installer.php
+++ b/src/MagentoHackathon/Composer/Magento/Installer.php
@@ -60,6 +60,12 @@ class Installer extends LibraryInstaller implements InstallerInterface
     protected $_deployStrategy = "symlink";
 
     /**
+     * @var array Path mapping prefixes that need to be translated (i.e. to
+     * use a public directory as the web server root).
+     */
+    protected $_pathMappingTranslations = array();
+
+    /**
      * Initializes Magento Module installer
      *
      * @param \Composer\IO\IOInterface $io
@@ -112,6 +118,10 @@ class Installer extends LibraryInstaller implements InstallerInterface
 
         if (!empty($extra['skip-package-deployment'])) {
             $this->skipPackageDeployment = true;
+        }
+
+        if (!empty($extra['path-mapping-translations'])) {
+            $this->_pathMappingTranslations = (array)$extra['path-mapping-translations'];
         }
     }
 
@@ -259,13 +269,13 @@ class Installer extends LibraryInstaller implements InstallerInterface
         $extra = $package->getExtra();
 
         if (isset($extra['map'])) {
-            $parser = new MapParser($extra['map']);
+            $parser = new MapParser($extra['map'], $this->_pathMappingTranslations);
             return $parser;
         } elseif (isset($extra['package-xml'])) {
-            $parser = new PackageXmlParser($this->getSourceDir($package), $extra['package-xml']);
+            $parser = new PackageXmlParser($this->getSourceDir($package), $extra['package-xml'], $this->_pathMappingTranslations);
             return $parser;
         } elseif (file_exists($this->getSourceDir($package) . '/modman')) {
-            $parser = new ModmanParser($this->getSourceDir($package));
+            $parser = new ModmanParser($this->getSourceDir($package), $this->_pathMappingTranslations);
             return $parser;
         } else {
             throw new \ErrorException('Unable to find deploy strategy for module: no known mapping');

--- a/src/MagentoHackathon/Composer/Magento/MapParser.php
+++ b/src/MagentoHackathon/Composer/Magento/MapParser.php
@@ -5,18 +5,20 @@
 
 namespace MagentoHackathon\Composer\Magento;
 
-class MapParser implements Parser {
+class MapParser extends PathTranslationParser {
 
     protected $_mappings = array();
 
-    function __construct( $mappings )
+    function __construct( $mappings, $translations = array() )
     {
+        parent::__construct($translations);
+
         $this->setMappings($mappings);
     }
 
     public function setMappings($mappings)
     {
-        $this->_mappings = $mappings;
+        $this->_mappings = $this->translatePathMappings($mappings);
     }
 
     public function getMappings()

--- a/src/MagentoHackathon/Composer/Magento/ModmanParser.php
+++ b/src/MagentoHackathon/Composer/Magento/ModmanParser.php
@@ -8,7 +8,7 @@ namespace MagentoHackathon\Composer\Magento;
 /**
  * Parsers modman files
  */
-class ModmanParser implements Parser
+class ModmanParser extends PathTranslationParser
 {
     /**
      * @var string Path to vendor module dir
@@ -25,8 +25,10 @@ class ModmanParser implements Parser
      *
      * @param string $moduleDir
      */
-    public function __construct($moduleDir = null)
+    public function __construct($moduleDir = null, $translations = array())
     {
+        parent::__construct($translations);
+
         $this->setModuleDir($moduleDir);
         $this->setFile($this->getModmanFile());
     }
@@ -102,6 +104,7 @@ class ModmanParser implements Parser
         }
 
         $map = $this->_parseMappings();
+        $map = $this->translatePathMappings($map);
         return $map;
     }
 

--- a/src/MagentoHackathon/Composer/Magento/PackageXmlParser.php
+++ b/src/MagentoHackathon/Composer/Magento/PackageXmlParser.php
@@ -8,7 +8,7 @@ namespace MagentoHackathon\Composer\Magento;
 /**
  * Parses Magento Connect 2.0 package.xml files
  */
-class PackageXmlParser implements Parser
+class PackageXmlParser extends PathTranslationParser
 {
     /**
      * @var string Path to vendor module dir
@@ -31,8 +31,10 @@ class PackageXmlParser implements Parser
      * @param string $moduleDir
      * @param string $packageXmlFile
      */
-    public function __construct($moduleDir, $packageXmlFile)
+    public function __construct($moduleDir, $packageXmlFile, $translations = array())
     {
+        parent::__construct($translations);
+
         $this->setModuleDir($moduleDir);
         $this->setFile($this->getModuleDir() . '/' . $packageXmlFile);
     }
@@ -96,6 +98,7 @@ class PackageXmlParser implements Parser
         }
 
         $map = $this->_parseMappings();
+        $map = $this->translatePathMappings($map);
         return $map;
     }
 

--- a/src/MagentoHackathon/Composer/Magento/PathTranslationParser.php
+++ b/src/MagentoHackathon/Composer/Magento/PathTranslationParser.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace MagentoHackathon\Composer\Magento;
+
+/**
+ * Parser class supporting translating path mappings according to
+ * the composer.json configuration.
+ */
+abstract class PathTranslationParser implements Parser
+{
+    /**
+     * @var array Variants on each prefix that path mappings are checked
+     * against.
+     */
+    protected $pathPrefixVariants = array('', './');
+
+    /**
+     * @var array Path mapping prefixes that need to be translated (i.e. to
+     * use a public directory as the web server root).
+     */
+    protected $pathPrefixTranslations = array();
+
+    /**
+     * Constructor. Sets the list of path translations to use.
+     *
+     * @param array $translations Path translations
+     */
+    public function __construct($translations)
+    {
+        $this->pathPrefixTranslations = $this->createPrefixVariants($translations);
+    }
+
+    /**
+     * Given an array of path mapping translations, combine them with a list
+     * of starting variations. This is so that a translation for 'js' will
+     * also match path mappings beginning with './js'.
+     *
+     * @param $translations
+     * @return array
+     */
+    protected function createPrefixVariants($translations)
+    {
+        $newTranslations = array();
+        foreach($translations as $key => $value) {
+            foreach($this->pathPrefixVariants as $variant) {
+                $newTranslations[$variant.$key] = $value;
+            }
+        }
+
+        return $newTranslations;
+    }
+
+    /**
+     * Given a list of path mappings, check if any of the targets are for
+     * directories that have been moved under the public directory. If so,
+     * update the target paths to include 'public/'. As no standard Magento
+     * path mappings should ever start with 'public/', and  path mappings
+     * that already include the public directory should always have
+     * js/skin/media paths starting with 'public/', it should be safe to call
+     * multiple times on either.
+     *
+     * @param $mappings Array of path mappings
+     * @return array Updated path mappings
+     */
+    public function translatePathMappings($mappings)
+    {
+        // each element of $mappings is an array with two elements; first is
+        // the source and second is the target
+        foreach($mappings as &$mapping) {
+            foreach($this->pathPrefixTranslations as $prefix => $translate) {
+                if(strpos($mapping[1], $prefix) === 0) {
+                    // replace the old prefix with the translated version
+                    $mapping[1] = $translate . substr($mapping[1], strlen($prefix));
+                    // should never need to translate a prefix more than once
+                    // per path mapping
+                    break;
+                }
+            }
+        }
+
+        return $mappings;
+    }
+}

--- a/tests/MagentoHackathon/Composer/Magento/InstallerTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/InstallerTest.php
@@ -136,4 +136,115 @@ class InstallerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('MagentoHackathon\Composer\Magento\MapParser', $this->object->getParser($package));
     }
+
+    /*
+     * Test that path mapping translation code doesn't have any effect when no
+     * translations are specified.
+     */
+
+    protected function createPathMappingTranslationMock()
+    {
+        return $this->createPackageMock(
+            array(
+                'map' => array(
+                    array('src/app/etc/modules/Example_Name.xml',   'app/etc/modules/Example_Name.xml'),
+                    array('src/app/code/community/Example/Name',    'app/code/community/Example/Name'),
+                    array('src/skin',                               'skin/frontend/default/default/examplename'),
+                    array('src/js',                                 'js/examplename'),
+                    array('src/media/images',                       'media/examplename_images'),
+                    array('src2/skin',                              './skin/frontend/default/default/examplename'),
+                    array('src2/js',                                './js/examplename'),
+                    array('src2/media/images',                      './media/examplename_images'),
+                )
+            )
+        );
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testEtcPathMappingTranslation()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src/app/etc/modules/Example_Name.xml', 'app/etc/modules/Example_Name.xml'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testCodePathMappingTranslation()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src/app/code/community/Example/Name', 'app/code/community/Example/Name'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testJSPathMappingTranslation()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src/js', 'js/examplename'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testSkinPathMappingTranslation()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src/skin', 'skin/frontend/default/default/examplename'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testMediaPathMappingTranslation()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src/media/images', 'media/examplename_images'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testJSPathMappingTranslation2()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src2/js', './js/examplename'),$mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testSkinPathMappingTranslation2()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src2/skin', './skin/frontend/default/default/examplename'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testMediaPathMappingTranslation2()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src2/media/images', './media/examplename_images'), $mappings);
+    }
 }

--- a/tests/MagentoHackathon/Composer/Magento/PathMappingTranslationTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/PathMappingTranslationTest.php
@@ -1,0 +1,148 @@
+<?php
+namespace MagentoHackathon\Composer\Magento;
+
+use Composer\Installer\LibraryInstaller;
+use Composer\Util\Filesystem;
+use Composer\Test\TestCase;
+use Composer\Composer;
+use Composer\Config;
+
+/**
+ * Test that path mapping translations work correctly, including different
+ * prefix types (i.e. 'js/...' vs './js/...').
+ */
+class PathMappingTranslationTest extends InstallerTest
+{
+    protected function setUp()
+    {
+        $this->fs = new Filesystem;
+
+
+        $this->vendorDir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'composer-test-vendor';
+        $this->fs->ensureDirectoryExists($this->vendorDir);
+
+        $this->binDir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'composer-test-bin';
+        $this->fs->ensureDirectoryExists($this->binDir);
+
+        $this->magentoDir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'composer-test-magento';
+        $this->fs->ensureDirectoryExists($this->magentoDir);
+
+        $this->composer = new Composer();
+        $this->config = new Config();
+        $this->composer->setConfig($this->config);
+        $this->composer->setPackage($this->createPackageMock(
+            array(
+                'path-mapping-translations' => array(
+                    'js/'       =>  'public/js/',
+                    'media/'    =>  'public/media/',
+                    'skin/'     =>  'public/skin/',
+                )
+            )
+        ));
+
+        $this->config->merge(array(
+            'config' => array(
+                'vendor-dir' => $this->vendorDir,
+                'bin-dir' => $this->binDir,
+            ),
+        ));
+
+        $this->dm = $this->getMockBuilder('Composer\Downloader\DownloadManager')
+                ->disableOriginalConstructor()
+                ->getMock();
+        $this->composer->setDownloadManager($this->dm);
+
+        $this->repository = $this->getMock('Composer\Repository\InstalledRepositoryInterface');
+        $this->io = $this->getMock('Composer\IO\IOInterface');
+
+        $this->object = new Installer($this->io, $this->composer);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testEtcPathMappingTranslation()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src/app/etc/modules/Example_Name.xml', 'app/etc/modules/Example_Name.xml'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testCodePathMappingTranslation()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src/app/code/community/Example/Name', 'app/code/community/Example/Name'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testJSPathMappingTranslation()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src/js', 'public/js/examplename'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testSkinPathMappingTranslation()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src/skin', 'public/skin/frontend/default/default/examplename'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testMediaPathMappingTranslation()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src/media/images', 'public/media/examplename_images'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testJSPathMappingTranslation2()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src2/js', 'public/js/examplename'),$mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testSkinPathMappingTranslation2()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src2/skin', 'public/skin/frontend/default/default/examplename'), $mappings);
+    }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\Installer::getMappings
+     */
+    public function testMediaPathMappingTranslation2()
+    {
+        $package = $this->createPathMappingTranslationMock();
+        $mappings = $this->object->getParser($package)->getMappings();
+
+        $this->assertContains(array('src2/media/images', 'public/media/examplename_images'), $mappings);
+    }
+}


### PR DESCRIPTION
This pull request adds the ability to specify a set of translations that are applied to the path mappings magento-composer-installer uses to symlink extension files. This is useful if some types of extension files need to be linked into non-standard locations.

We maintain a Magento fork called Mercator (https://github.com/mercator). One change we made in Mercator was to put web-accessible files (CSS, JS, images) under a 'public' directory. This can then be used as the web server's document root, preventing accidentally exposing private files (i.e. local.xml).

This change to the file structure means that extensions that include public files need to be handled correctly. We use Composer to manage the extensions included in Mercator, so one option would have been to rewrite the modman files/composer.json map sections/etc for all of them. However, this required making backwards-incompatible changes and made it harder to add extensions. Instead, we modified magento-composer-installer to allow specifying a set of transformations. These are applied to each path mapping, and allow us to have web-accessible files automatically moved into the public directory. This allows extensions to be installed without changing their path mapping information. We thought this functionality might be useful to anybody running a similarly-modified version of Magento.

For example, the set of path mappings we specify in Mercator's composer.json are:

``` json
    "extra": {
        "path-mapping-translations": {
            "js/":      "public/js/",
            "media/":   "public/media/",
            "skin/":    "public/skin/"
        }
    }
```

A partial example of a modman file used by one of the included extensions:

```
app/code/community/BL/CustomGrid/               app/code/community/BL/CustomGrid/
app/etc/modules/BL_CustomGrid.xml               app/etc/modules/BL_CustomGrid.xml
app/locale/fr_FR/BL_CustomGrid.csv              app/locale/fr_FR/BL_CustomGrid.csv
js/bl/customgrid/                               js/bl/customgrid/
skin/adminhtml/default/default/bl/customgrid/   skin/adminhtml/default/default/bl/customgrid/
```

With the above path mappings in place, when this modman file is processed it will be interpreted as:

```
app/code/community/BL/CustomGrid/               app/code/community/BL/CustomGrid/
app/etc/modules/BL_CustomGrid.xml               app/etc/modules/BL_CustomGrid.xml
app/locale/fr_FR/BL_CustomGrid.csv              app/locale/fr_FR/BL_CustomGrid.csv
js/bl/customgrid/                               public/js/bl/customgrid/
skin/adminhtml/default/default/bl/customgrid/   public/skin/adminhtml/default/default/bl/customgrid/
```

The 'skin' and 'js' files will be linked into place under the public directory, while everything that wasn't translated will be linked as normal.
