### PR TITLE
Fix verbose option check

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Installer.php
+++ b/src/MagentoHackathon/Composer/Magento/Installer.php
@@ -558,7 +558,7 @@ class Installer extends LibraryInstaller implements InstallerInterface
 
             if ($ioInterface->isVerbose()) {
                 $ioInterface->write($package->getName());
-            $ioInterface->write($package->getType());
+                $ioInterface->write($package->getType());
             }
 
             if ($package->getType() != "magento-module") {
@@ -569,8 +569,8 @@ class Installer extends LibraryInstaller implements InstallerInterface
             }
 
             $strategy = $moduleInstaller->getDeployStrategy($package);
-            if ($ioInterface->getOption('verbose')) {
-            $ioInterface->write("used " . get_class($strategy) . " as deploy strategy");
+            if ($ioInterface->isVerbose()) {
+                $ioInterface->write("used " . get_class($strategy) . " as deploy strategy");
             }
             $strategy->setMappings($moduleInstaller->getParser($package)->getMappings());
 


### PR DESCRIPTION
fixes: "PHP Fatal error:  Call to undefined method Composer\IO\ConsoleIO::getOption() in
magento-hackathon/magento-composer-installer/src/MagentoHackathon/Composer/Magento/Installer.php on line 572"
- add aditional indent on line 561 + 573
