### PR TITLE
Revert "Fix "Could not delete" Exception on removeDirectory"

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
@@ -428,7 +428,7 @@ abstract class DeploystrategyAbstract
     {
         $fs = new \Composer\Util\Filesystem();
         if(is_dir($dir)){
-            $result = $fs->removeDirectory(rtrim($dir,'/'));
+            $result = $fs->removeDirectory($dir);
         }else{
             @unlink($dir);
         }


### PR DESCRIPTION
This reverts commit b8ccfdfd81439f41396ec8d0b28d7f43e7d6a25e.

It is not necessary any longer.

It was a fix for a problem reported in #122.

Which has fixed upstream in composer as it was a problem there.
- https://github.com/magento-hackathon/magento-composer-installer/issues/122
- https://github.com/composer/composer/pull/3158
- https://github.com/composer/composer/pull/3159
