### PR TITLE
Removed unneccessary trailing f-slash in SYMLINKD

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Symlink.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Symlink.php
@@ -128,10 +128,6 @@ class Symlink extends DeploystrategyAbstract
      */
     public function getRelativePath($from, $to)
     {
-        // Can't use realpath() here since the destination doesn't exist yet
-        $from = is_dir($from) ? rtrim($from, '\/') . '/' : $from;
-        $to = is_dir($to) ? rtrim($to, '\/') . '/' : $to;
-
         $from = str_replace('\\', '/', $from);
         $to = str_replace('\\', '/', $to);
 


### PR DESCRIPTION
Trailing forward slashes in SYMLINKD may cause errors in php include.
