### PR TITLE
Allow to deactivate core installer

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
+++ b/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
@@ -35,6 +35,8 @@ class ProjectConfig
 
     const PATH_MAPPINGS_TRANSLATIONS_KEY = 'path-mapping-translations';
 
+    const DISABLE_CORE_INSTALLER = 'disable-core-installer';
+
     // Default Values
     const DEFAULT_MAGENTO_ROOT_DIR = 'root';
 
@@ -380,5 +382,15 @@ class ProjectConfig
         }
 
         return $arrayNew;
+    }
+
+    /**
+     * Whether or not the disable core installer flag has been passed
+     *
+     * @return bool
+     */
+    public function hasDisableCoreInstaller()
+    {
+        return $this->hasExtraField(self::DISABLE_CORE_INSTALLER);
     }
 }


### PR DESCRIPTION
Hi, I added an option to disable the core installer, which should solve #148. I didn't see any tests for this class, so i didn't add any. I can do if needs be. 

Let me know if the solution is not the preferred one. 

I refactored a little so I didn't have to do the following check in `onNewCodeEvent`

```
if (null !=== $this->deployManagerCore) {
    $this->deployManagerCore->doDeploy();
}
```
