### PR TITLE
Fix for issue #165

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Installer/CoreInstaller.php
+++ b/src/MagentoHackathon/Composer/Magento/Installer/CoreInstaller.php
@@ -150,6 +150,7 @@ class CoreInstaller extends MagentoInstallerAbstract
     {
         $deployStrategy = new Core($this->getSourceDir($package), $this->getTargetDir());
         $deployStrategy->setIgnoredMappings($this->getModuleSpecificDeployIgnores($package));
+        $deployStrategy->setIsForced($this->isForced);
         return $deployStrategy;
     }
 }


### PR DESCRIPTION
I think this also useful option for core deploy in cases when in project repo saved only local scope magento code. 
When capistrano deploying code, then media folder (as shared in capistrano) already exists across releases, but in magento-core package media and var exist too, so composer throw exception like in #165 issue.