### PR TITLE
Remove unused $persistentDirs

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Installer/CoreInstaller.php
+++ b/src/MagentoHackathon/Composer/Magento/Installer/CoreInstaller.php
@@ -75,17 +75,6 @@ class CoreInstaller extends MagentoInstallerAbstract
         );
 
     /**
-     * Directories that persist between Updates
-     *
-     * @var array
-     */
-    protected $persistentDirs
-        = array(
-            'media',
-            'var'
-        );
-
-    /**
      * @param IOInterface $io
      * @param Composer    $composer
      * @param string      $type


### PR DESCRIPTION
I don't think this is used, or am I overlooking something?
It is used here: https://github.com/magento-hackathon/magento-composer-installer/blob/a0765d8466a22db662668c999c7cc4576e242c80/src/MagentoHackathon/Composer/Magento/Deploystrategy/Core.php#L130-L140 but that has it's own variable, so this might be confusing.