### PR TITLE
Avoid installing magento-core in modman folder.

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Installer/CoreInstaller.php
+++ b/src/MagentoHackathon/Composer/Magento/Installer/CoreInstaller.php
@@ -153,4 +153,24 @@ class CoreInstaller extends MagentoInstallerAbstract
         $deployStrategy->setIsForced($this->isForced);
         return $deployStrategy;
     }
+
+    /**
+     * Returns the installation path of a package
+     * We don't use the parent class for this because Magento Core should never be installed in  the modman-root-dir
+     *
+     * @param  PackageInterface $package
+     * @return string           path
+     */
+    public function getInstallPath(PackageInterface $package)
+    {
+        $targetDir = $package->getTargetDir();
+        $installPath = $this->getPackageBasePath($package) . ($targetDir ? '/'.$targetDir : '');
+
+        // Make install path absolute. This is needed in the symlink deploy strategies.
+        if (DIRECTORY_SEPARATOR !== $installPath[0] && $installPath[1] !== ':') {
+            $installPath = getcwd() . "/$installPath";
+        }
+
+        return $installPath;
+    }
 }

--- a/src/MagentoHackathon/Composer/Magento/Installer/MagentoInstallerAbstract.php
+++ b/src/MagentoHackathon/Composer/Magento/Installer/MagentoInstallerAbstract.php
@@ -485,9 +485,7 @@ abstract class MagentoInstallerAbstract extends LibraryInstaller implements Inst
      */
     public function getInstallPath(PackageInterface $package)
     {
-        var_dump($this->modmanRootDir);
-        var_dump(!is_null($this->modmanRootDir));
-        var_dump($this->modmanRootDir->isDir());
+
         if (!is_null($this->modmanRootDir) && true === $this->modmanRootDir->isDir()) {
             $targetDir = $package->getTargetDir();
             if (!$targetDir) {

--- a/src/MagentoHackathon/Composer/Magento/Installer/MagentoInstallerAbstract.php
+++ b/src/MagentoHackathon/Composer/Magento/Installer/MagentoInstallerAbstract.php
@@ -485,7 +485,9 @@ abstract class MagentoInstallerAbstract extends LibraryInstaller implements Inst
      */
     public function getInstallPath(PackageInterface $package)
     {
-
+        var_dump($this->modmanRootDir);
+        var_dump(!is_null($this->modmanRootDir));
+        var_dump($this->modmanRootDir->isDir());
         if (!is_null($this->modmanRootDir) && true === $this->modmanRootDir->isDir()) {
             $targetDir = $package->getTargetDir();
             if (!$targetDir) {


### PR DESCRIPTION
When using a specific `modman-root-dir` the `magento-core` package would be installed inside the modman directory.

#### Config:
```json
    "extra":{
        "magento-root-dir": "htdocs/",
        "modman-root-dir": "htdocs/.modman"
    }
```

#### Result of using the wrong installation path:
```
htdocs/
├── .htaccess
├── .modman
│   └── core
│       ├── .htaccess
│       ├── .htaccess.sample
│       ├── LICENSE.html
│       ├── LICENSE.txt
│       ├── LICENSE_AFL.txt
│       ├── RELEASE_NOTES.txt
│       ├── api.php
│       ├── app
│       ├── composer.json
│       ├── cron.php
│       ├── ...
├── app
│   ├── .htaccess
│   ├── Mage.php
│   ├── code
│   │   ├── community
│   │   └── core
│   ├── design
│   │   ├── adminhtml
│   │   ├── frontend
│   │   └── install
│   ├── ...
```

After applying this pull request the `magento-core` package is installed in the `vendor` directory while the `magento-modules` are still installed in the `modman-root-dir`.