### PR TITLE
Clarify a vague exception

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Installer/MagentoInstallerAbstract.php
+++ b/src/MagentoHackathon/Composer/Magento/Installer/MagentoInstallerAbstract.php
@@ -476,7 +476,7 @@ abstract class MagentoInstallerAbstract extends LibraryInstaller implements Inst
 
             return $parser;
         } else {
-            throw new \ErrorException('Unable to find deploy strategy for module: no known mapping');
+            throw new \ErrorException('Unable to find deploy strategy for module ' . $package->getName() . ': no known mapping');
         }
     }
 


### PR DESCRIPTION
Unable to find deploy strategy for module: no known mapping will now become
Unable to find deploy strategy for module [package/name]: no known mapping