### PR TITLE
Fixing modman file parser

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/ModmanParser.php
+++ b/src/MagentoHackathon/Composer/Magento/ModmanParser.php
@@ -125,10 +125,14 @@ class ModmanParser extends PathTranslationParser
                 continue;
             }
             $parts = preg_split('/\s+/', $row, 2, PREG_SPLIT_NO_EMPTY);
-            if (count($parts) != 2) {
-                throw new \ErrorException(sprintf('Invalid row on line %d has %d parts, expected 2', $line, count($row)));
+            if (count($parts) === 1) {
+                $part = reset($parts);
+                $map[] = array($part, $part);
+            } elseif (count($parts) === 2) {
+                $map[] = $parts;
+            } else {
+                throw new \ErrorException(sprintf('Invalid row on line %d has %d parts, expected 1 or 2', $line, count($row)));
             }
-            $map[] = $parts;
         }
         return $map;
     }

--- a/tests/MagentoHackathon/Composer/Magento/ModmanParserTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/ModmanParserTest.php
@@ -82,4 +82,17 @@ class ModmanParserTest extends \PHPUnit_Framework_TestCase
         $this->object->setFile($this->modmanFileDir . 'modman');
         $this->assertSame($expected, $this->object->getMappings());
     }
+
+    /**
+     * @covers MagentoHackathon\Composer\Magento\ModmanParser::getMappings
+     */
+    public function testGetMappingsNew()
+    {
+        $expected = array(
+            array('line/one', 'line/one'),
+            array('line/two', 'line/two'),
+        );
+        $this->object->setFile($this->modmanFileDir . 'modman.new_format');
+        $this->assertSame($expected, $this->object->getMappings());
+    }
 }

--- a/tests/MagentoHackathon/Composer/Magento/data/ModmanParserTest/modman.new_format
+++ b/tests/MagentoHackathon/Composer/Magento/data/ModmanParserTest/modman.new_format
@@ -1,0 +1,9 @@
+
+line/one
+line/two
+
+#this is a comment which will be ignored
+
+@shell This won't run
+@import This/Will/Be/Ignored/Too
+


### PR DESCRIPTION
modman supports a short syntax where a single file path indicates that
the destination matches the source. This has been supported by modman
since 1.9.2 (really 1.9.0) which was released on May 3rd, 2013.